### PR TITLE
chore(npm): allow installing without husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "format": "prettier -w **",
     "postinstall": "is-ci || husky install",
+    "postpublish": "pinst --enable",
     "prepare": "tsc -p source",
+    "prepublishOnly": "pinst --disable",
     "test": "prettier -c ** && tsc -p type-tests && ava"
   },
   "files": [
@@ -34,6 +36,7 @@
     "eslint": "^7.20.0",
     "husky": "^5.0.9",
     "is-ci": "^2.0.0",
+    "pinst": "^2.1.6",
     "prettier": "^2.2.1",
     "prettier-plugin-package": "^1.3.0",
     "ts-node": "^9.1.1",


### PR DESCRIPTION
Add `pinst` as suggested by https://typicode.github.io/husky/#/?id=install-1

Otherwise installing the package fails with...

```
╰─$ yarn init -y && yarn add ts-opaque                                                                               1 ↵
yarn init v1.22.10
warning The yes flag has been set. This will automatically answer yes to all questions, which may have security implications.
success Saved package.json
✨  Done in 0.02s.
yarn add v1.22.10
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
error /Users/karel/ts-opaque-install/node_modules/ts-opaque: Command failed.
Exit code: 127
Command: is-ci || husky install
Arguments:
Directory: /Users/karel/ts-opaque-install/node_modules/ts-opaque
Output:
/bin/sh: is-ci: command not found
/bin/sh: husky: command not found
```
